### PR TITLE
Added ability to use completion block on "close menu and change content view controller" operations

### DIFF
--- a/DBBasementController/DBBasementController.h
+++ b/DBBasementController/DBBasementController.h
@@ -38,6 +38,7 @@
 - (void)openMenuAnimated:(BOOL)animated;
 - (void)closeMenuAnimated:(BOOL)animated;
 - (void)closeMenuAndChangeContentViewController:(UIViewController *)viewController animated:(BOOL)animated;
+- (void)closeMenuAndChangeContentViewController:(UIViewController *)viewController animated:(BOOL)animated completion:(void (^)())closeCompletionBlock;
 - (void)toggleMenu;
 
 - (BOOL)menuIsOpen;

--- a/DBBasementController/DBBasementController.m
+++ b/DBBasementController/DBBasementController.m
@@ -218,9 +218,7 @@ typedef struct {
             
             [self closeMenuAnimated:animated completion:^{
                 if (callAppearanceMethods) [viewController endAppearanceTransition];
-                if (closeCompletionBlock) {
-                    closeCompletionBlock();
-                }
+                if (closeCompletionBlock) closeCompletionBlock();
             }];
         }];
         
@@ -234,9 +232,7 @@ typedef struct {
         
         [self closeMenuAnimated:animated completion:^{
             if (callAppearanceMethods) [viewController endAppearanceTransition];
-            if (closeCompletionBlock) {
-                closeCompletionBlock();
-            }
+            if (closeCompletionBlock) closeCompletionBlock();
         }];
     }
 }

--- a/DBBasementController/DBBasementController.m
+++ b/DBBasementController/DBBasementController.m
@@ -191,7 +191,12 @@ typedef struct {
     } completion:completionBlock];
 }
 
-- (void)closeMenuAndChangeContentViewController:(UIViewController *)viewController animated:(BOOL)animated {
+- (void)closeMenuAndChangeContentViewController:(UIViewController *)viewController animated:(BOOL)animated
+{
+    [self closeMenuAndChangeContentViewController:viewController animated:animated completion:nil];
+}
+
+- (void)closeMenuAndChangeContentViewController:(UIViewController *)viewController animated:(BOOL)animated completion:(void (^)())closeCompletionBlock {
     UIViewController *oldContentViewController = self.contentViewController;
     //If the view controllers are the same we don't need to bother with appearance transition calls
     BOOL callAppearanceMethods = oldContentViewController != viewController;
@@ -213,6 +218,9 @@ typedef struct {
             
             [self closeMenuAnimated:animated completion:^{
                 if (callAppearanceMethods) [viewController endAppearanceTransition];
+                if (closeCompletionBlock) {
+                    closeCompletionBlock();
+                }
             }];
         }];
         
@@ -226,6 +234,9 @@ typedef struct {
         
         [self closeMenuAnimated:animated completion:^{
             if (callAppearanceMethods) [viewController endAppearanceTransition];
+            if (closeCompletionBlock) {
+                closeCompletionBlock();
+            }
         }];
     }
 }


### PR DESCRIPTION
I think ability to add completion block to "close meny and change content view controller" might be very useful for sequences of actions, that require certain state of BasementController
