### PR TITLE
Fix of duplicate appearance selectors calls on iOS 5

### DIFF
--- a/DBBasementController/DBBasementController.m
+++ b/DBBasementController/DBBasementController.m
@@ -199,7 +199,8 @@ typedef struct {
 - (void)closeMenuAndChangeContentViewController:(UIViewController *)viewController animated:(BOOL)animated completion:(void (^)())closeCompletionBlock {
     UIViewController *oldContentViewController = self.contentViewController;
     //If the view controllers are the same we don't need to bother with appearance transition calls
-    BOOL callAppearanceMethods = oldContentViewController != viewController;
+    //Appearance methods are called for us on iOS 5, so don't bother nither
+    BOOL callAppearanceMethods = oldContentViewController != viewController && [[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0;
     
     if (self.options.bounceWhenNavigating && animated && [self menuIsOpen]) {
         CGFloat offscreenDistance = 10.0f;


### PR DESCRIPTION
It turned out that iOS 5 is calling appearance selectors on even on
adding view as a subview, no need to manually call appearance
selectors. I fixed the issue by making disabling appearance selectors
for iOS 5 or lower.
